### PR TITLE
[feat] Implemented Health Checks for budget and transaction service

### DIFF
--- a/budget-service/pom.xml
+++ b/budget-service/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
         <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-client</artifactId>
         </dependency>

--- a/budget-service/src/main/java/com/budget/budget/health/BudgetDatabaseReadinessCheck.java
+++ b/budget-service/src/main/java/com/budget/budget/health/BudgetDatabaseReadinessCheck.java
@@ -1,0 +1,26 @@
+package com.budget.budget.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Readiness;
+import io.agroal.api.AgroalDataSource;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+@Readiness
+@ApplicationScoped
+public class BudgetDatabaseReadinessCheck implements HealthCheck {
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Override
+    public HealthCheckResponse call() {
+        try (var connection = dataSource.getConnection()) {
+            return HealthCheckResponse.up("Budget database is ready");
+        } catch (Exception e) {
+            return HealthCheckResponse.down("Budget database is not ready");
+        }
+    }
+
+}

--- a/budget-service/src/main/java/com/budget/budget/health/BudgetServiceLivenessCheck.java
+++ b/budget-service/src/main/java/com/budget/budget/health/BudgetServiceLivenessCheck.java
@@ -1,0 +1,16 @@
+package com.budget.budget.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Liveness;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+@Liveness
+@ApplicationScoped
+public class BudgetServiceLivenessCheck implements HealthCheck{
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.up("Budget service is alive");
+    }
+}

--- a/transaction-service/pom.xml
+++ b/transaction-service/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>   
         <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-client</artifactId>
         </dependency>   

--- a/transaction-service/src/main/java/com/budget/transaction/health/TransactionDatabaseReadinessCheck.java
+++ b/transaction-service/src/main/java/com/budget/transaction/health/TransactionDatabaseReadinessCheck.java
@@ -1,0 +1,27 @@
+package com.budget.transaction.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Readiness;
+import io.agroal.api.AgroalDataSource;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+
+@Readiness
+@ApplicationScoped
+public class TransactionDatabaseReadinessCheck implements HealthCheck {
+    
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Override
+    public HealthCheckResponse call() {
+        try (var connection = dataSource.getConnection()) {
+            return HealthCheckResponse.up("Transaction database is ready");
+        } catch (Exception e) {
+            return HealthCheckResponse.down("Transaction database is not ready");
+        }
+    }
+    
+}

--- a/transaction-service/src/main/java/com/budget/transaction/health/TransactionServiceLivenessCheck.java
+++ b/transaction-service/src/main/java/com/budget/transaction/health/TransactionServiceLivenessCheck.java
@@ -1,0 +1,16 @@
+package com.budget.transaction.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+@Liveness
+@ApplicationScoped
+public class TransactionServiceLivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.up("Transaction service is alive");
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Connected: #19 
- [ x] Issue resolved

## 📄 Work Description
This feature introduces MicroProfile Health checks using Quarkus SmallRye Health.
Two health checks were added: Live Check (Confirms the service is running) and Readiness Check (verifies the database connection is available).
If the DB is down, the readiness endpoint will report DOWN, which prevents traffic from being routed to the service. This would enable proper self-healing behavior in orchestration environments.

## 📌 Type of Change
<!-- Please check the relevant options -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Performance improvement

## 💉Testing
- [ x] Manual testing completed

### Test Details
Budget-Service
GET /q/health
<img width="1065" height="596" alt="http:::localhost:8081:q:health" src="https://github.com/user-attachments/assets/6431187d-660e-4e0a-a8b0-1af22683badf" />

GET /q/health/live
<img width="1068" height="485" alt="8081:q:health:live" src="https://github.com/user-attachments/assets/19f977d6-148b-4a43-afa8-60f8c9b72933" />

GET /q/health/ready
When the DB is UP:
<img width="1072" height="593" alt="8081:q:health:ready-DB-UP" src="https://github.com/user-attachments/assets/52dcc43d-e4eb-4e10-8207-aeb0609d6491" />
When the DB is DOWN:
<img width="1056" height="604" alt="8081:q:health:ready-DB-DOWN" src="https://github.com/user-attachments/assets/8031d188-eacb-4c34-b979-373e9cbf6a70" />

Transaction-Service:
GET /q/health
<img width="1074" height="584" alt="8082:q:health" src="https://github.com/user-attachments/assets/52a87251-0137-4492-bfcf-fea99d4ee2ec" />

GET /q/health/live
<img width="1069" height="549" alt="8082:q:health:live" src="https://github.com/user-attachments/assets/642cf991-f1b0-4ca6-b9ea-9d1dfb3e9433" />

GET /q/health/ready
When the DB is UP:
<img width="1072" height="586" alt="8082:q:health:ready-DB-UP" src="https://github.com/user-attachments/assets/9ffbc213-7f98-4ed3-8aa1-9b0daef63187" />
When the DB is DOWN:
<img width="1078" height="598" alt="8082:q:health:ready-DB-DOWN" src="https://github.com/user-attachments/assets/fb9237d5-3073-4695-bb40-393c4746e51d" />

## ✅Checklist
- [ x] My code follows the style guidelines of this project

## 📚References
https://quarkus.io/guides/smallrye-health
